### PR TITLE
Test: Add Full Unit Test Coverage for Controller Layer

### DIFF
--- a/CloudSyncTests/Unit/EmployeeManagement/Controllers/DepartmentControllerTests.cs
+++ b/CloudSyncTests/Unit/EmployeeManagement/Controllers/DepartmentControllerTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using CloudSync.Modules.EmployeeManagement.Controllers;
+using CloudSync.Modules.EmployeeManagement.Services.Interfaces;
+using CloudSync.Modules.EmployeeManagement.Services.Exceptions;
+using Shared.EmployeeManagement.Responses;
+
+namespace Tests.Unit.EmployeeManagement.Controllers
+{
+    public class DepartmentControllerTests
+    {
+        private readonly Mock<IDepartmentService> _departmentServiceMock;
+        private readonly DepartmentController _controller;
+
+        public DepartmentControllerTests()
+        {
+            _departmentServiceMock = new Mock<IDepartmentService>();
+            _controller = new DepartmentController(_departmentServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task GetAllDepartments_WhenDepartmentsExist_ReturnsOkWithList()
+        {
+            // Arrange
+            var departments = new List<DepartmentResponse>
+            {
+                new DepartmentResponse(),
+                new DepartmentResponse()
+            };
+
+            _departmentServiceMock.Setup(s => s.GetAllAsync()).ReturnsAsync(departments);
+
+            // Act
+            var result = await _controller.GetAllDepartments();
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(departments, ok.Value);
+
+            _departmentServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllDepartments_WhenNoDepartments_ReturnsOkWithEmptyList()
+        {
+            // Arrange
+            _departmentServiceMock.Setup(s => s.GetAllAsync()).ReturnsAsync(new List<DepartmentResponse>());
+
+            // Act
+            var result = await _controller.GetAllDepartments();
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var list = Assert.IsAssignableFrom<IEnumerable<DepartmentResponse>>(ok.Value);
+            Assert.Empty(list);
+
+            _departmentServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllDepartments_WhenServiceThrowsDepartmentException_ReturnsStatusCodeWithMessage()
+        {
+            // Arrange
+            var statusCode = 503;
+            var message = "Service unavailable";
+            var exception = new DepartmentException(message, statusCode);
+
+            _departmentServiceMock.Setup(s => s.GetAllAsync()).ThrowsAsync(exception);
+
+            // Act
+            var result = await _controller.GetAllDepartments();
+
+            // Assert
+            var obj = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(statusCode, obj.StatusCode);
+            Assert.Equal(message, obj.Value);
+
+            _departmentServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllDepartments_WhenServiceThrowsUnexpectedException_PropagatesException()
+        {
+            // Arrange
+            _departmentServiceMock.Setup(s => s.GetAllAsync())
+                                  .ThrowsAsync(new InvalidOperationException("Unexpected"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.GetAllDepartments());
+            _departmentServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+    }
+}

--- a/CloudSyncTests/Unit/EmployeeManagement/Controllers/EmployeeControllerTests.cs
+++ b/CloudSyncTests/Unit/EmployeeManagement/Controllers/EmployeeControllerTests.cs
@@ -1,0 +1,289 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using CloudSync.Modules.EmployeeManagement.Controllers;
+using CloudSync.Modules.EmployeeManagement.Services.Interfaces;
+using Shared.EmployeeManagement.Requests;
+using Shared.EmployeeManagement.Responses;
+
+namespace Tests.Unit.EmployeeManagement.Controllers
+{
+    public class EmployeeControllerTests
+    {
+        private readonly Mock<IEmployeeService> _employeeServiceMock;
+        private readonly EmployeeController _controller;
+
+        public EmployeeControllerTests()
+        {
+            _employeeServiceMock = new Mock<IEmployeeService>();
+            _controller = new EmployeeController(_employeeServiceMock.Object);
+        }
+
+        private static EmployeeResponse MakeEmployeeResponse(int id) => new EmployeeResponse
+        {
+            Id = id,
+            BasicInfo = new EmployeeBasicResponse(),
+            ContactInfo = new EmployeeContactInfoResponse()
+        };
+
+        [Fact]
+        public async Task GetAllEmployees_WhenEmployeesExist_ReturnsOkWithList()
+        {
+            // Arrange
+            var employees = new List<EmployeeResponse>
+            {
+                MakeEmployeeResponse(1),
+                MakeEmployeeResponse(2)
+            };
+
+            _employeeServiceMock.Setup(s => s.GetAllAsync()).ReturnsAsync(employees);
+
+            // Act
+            var result = await _controller.GetAllEmployees();
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(employees, ok.Value);
+
+            _employeeServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllEmployees_WhenNoEmployees_ReturnsOkWithEmptyList()
+        {
+            // Arrange
+            _employeeServiceMock.Setup(s => s.GetAllAsync()).ReturnsAsync(new List<EmployeeResponse>());
+
+            // Act
+            var result = await _controller.GetAllEmployees();
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var list = Assert.IsAssignableFrom<IEnumerable<EmployeeResponse>>(ok.Value);
+            Assert.Empty(list);
+
+            _employeeServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllEmployees_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            _employeeServiceMock.Setup(s => s.GetAllAsync())
+                                .ThrowsAsync(new InvalidOperationException("Service failure"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.GetAllEmployees());
+            _employeeServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetById_WithValidId_ReturnsOkWithEmployee()
+        {
+            // Arrange
+            var id = 123;
+            var employee = MakeEmployeeResponse(id);
+
+            _employeeServiceMock.Setup(s => s.GetByIdAsync(id)).ReturnsAsync(employee);
+
+            // Act
+            var result = await _controller.GetById(id);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(employee, ok.Value);
+
+            _employeeServiceMock.Verify(s => s.GetByIdAsync(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetById_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var id = 999;
+            _employeeServiceMock.Setup(s => s.GetByIdAsync(id))
+                                .ThrowsAsync(new KeyNotFoundException("Employee not found"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => _controller.GetById(id));
+            _employeeServiceMock.Verify(s => s.GetByIdAsync(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByDepartment_WithValidId_ReturnsOkWithList()
+        {
+            // Arrange
+            var departmentId = 42;
+            var employees = new List<EmployeeResponse>
+            {
+                MakeEmployeeResponse(1),
+                MakeEmployeeResponse(2)
+            };
+
+            _employeeServiceMock.Setup(s => s.GetByDepartmentAsync(departmentId))
+                                .ReturnsAsync(employees);
+
+            // Act
+            var result = await _controller.GetByDepartment(departmentId);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(employees, ok.Value);
+
+            _employeeServiceMock.Verify(s => s.GetByDepartmentAsync(departmentId), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByDepartment_WhenNoEmployees_ReturnsOkWithEmptyList()
+        {
+            // Arrange
+            var departmentId = 43;
+            _employeeServiceMock.Setup(s => s.GetByDepartmentAsync(departmentId))
+                                .ReturnsAsync(new List<EmployeeResponse>());
+
+            // Act
+            var result = await _controller.GetByDepartment(departmentId);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var list = Assert.IsAssignableFrom<IEnumerable<EmployeeResponse>>(ok.Value);
+            Assert.Empty(list);
+
+            _employeeServiceMock.Verify(s => s.GetByDepartmentAsync(departmentId), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByDepartment_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var departmentId = 44;
+            _employeeServiceMock.Setup(s => s.GetByDepartmentAsync(departmentId))
+                                .ThrowsAsync(new InvalidOperationException("Service failure"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.GetByDepartment(departmentId));
+            _employeeServiceMock.Verify(s => s.GetByDepartmentAsync(departmentId), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateEmployee_WithValidRequest_ReturnsOkWithResponse()
+        {
+            // Arrange
+            var request = new CreateEmployeeRequest { FirstName = "John", LastName = "Doe" };
+            var expected = MakeEmployeeResponse(100);
+
+            _employeeServiceMock.Setup(s => s.CreateAsync(request)).ReturnsAsync(expected);
+
+            // Act
+            var result = await _controller.CreateEmployee(request);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(expected, ok.Value);
+
+            _employeeServiceMock.Verify(s => s.CreateAsync(request), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateEmployee_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var request = new CreateEmployeeRequest { FirstName = "Jane", LastName = "Smith" };
+            _employeeServiceMock.Setup(s => s.CreateAsync(request))
+                                .ThrowsAsync(new InvalidOperationException("Create failed"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.CreateEmployee(request));
+            _employeeServiceMock.Verify(s => s.CreateAsync(request), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateEmployee_WhenRequestIsNull_PropagatesServiceException()
+        {
+            // Arrange
+            CreateEmployeeRequest? request = null;
+            _employeeServiceMock.Setup(s => s.CreateAsync(null!))
+                                .ThrowsAsync(new ArgumentNullException("request"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _controller.CreateEmployee(request!));
+            _employeeServiceMock.Verify(s => s.CreateAsync(null!), Times.Once);
+        }
+
+        [Fact]
+        public async Task PutEmployee_WithValidRequest_ReturnsNoContent()
+        {
+            // Arrange
+            var id = 5;
+            var request = new UpdateEmployeeRequest {};
+
+            _employeeServiceMock.Setup(s => s.UpdateAsync(id, request)).Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.PutEmployee(id, request);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+            _employeeServiceMock.Verify(s => s.UpdateAsync(id, request), Times.Once);
+        }
+
+        [Fact]
+        public async Task PutEmployee_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var id = 6;
+            var request = new UpdateEmployeeRequest {};
+
+            _employeeServiceMock.Setup(s => s.UpdateAsync(id, request))
+                                .ThrowsAsync(new InvalidOperationException("Update failed"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.PutEmployee(id, request));
+            _employeeServiceMock.Verify(s => s.UpdateAsync(id, request), Times.Once);
+        }
+
+        [Fact]
+        public async Task PutEmployee_WhenRequestIsNull_PropagatesServiceException()
+        {
+            // Arrange
+            var id = 7;
+            _employeeServiceMock.Setup(s => s.UpdateAsync(id, null!))
+                                .ThrowsAsync(new ArgumentNullException("request"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _controller.PutEmployee(id, null!));
+            _employeeServiceMock.Verify(s => s.UpdateAsync(id, null!), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteEmployee_WithValidId_ReturnsNoContent()
+        {
+            // Arrange
+            var id = 8;
+            _employeeServiceMock.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.DeleteEmployee(id);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+            _employeeServiceMock.Verify(s => s.DeleteAsync(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteEmployee_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var id = 9;
+            _employeeServiceMock.Setup(s => s.DeleteAsync(id))
+                                .ThrowsAsync(new KeyNotFoundException("Employee not found"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => _controller.DeleteEmployee(id));
+            _employeeServiceMock.Verify(s => s.DeleteAsync(id), Times.Once);
+        }
+    }
+}

--- a/CloudSyncTests/Unit/UserManagement/Controllers/AuthControllerTests.cs
+++ b/CloudSyncTests/Unit/UserManagement/Controllers/AuthControllerTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Mvc;
+using CloudSync.Modules.UserManagement.Controllers;
+using CloudSync.Modules.UserManagement.Services.Interfaces;
+using Moq;
+using Shared.Requests.UserManagement;
+using Shared.Responses.UserManagement;
+
+namespace Tests.Unit.UserManagement.Controllers
+{
+    public class AuthControllerTests
+    {
+        private readonly Mock<IAuthService> _authServiceMock;
+        private readonly AuthController _controller;
+
+        public AuthControllerTests()
+        {
+            _authServiceMock = new Mock<IAuthService>();
+            _controller = new AuthController(_authServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task GoogleLogin_WithValidRequest_ReturnsOkWithServiceResponse()
+        {
+            // Arrange
+            var request = new GoogleLoginRequest
+            {
+                IdToken = "test-token"
+            };
+
+            var expectedResponse = new GoogleLoginResponse
+            {
+                JsonWebToken = "jwt-token-123",
+                User = new UserResponse
+                {
+                    Id = 1,
+                    Email = "user@example.com",
+                    CreateDateTime = DateTime.UtcNow.AddDays(-10),
+                    LastLoginDateTime = DateTime.UtcNow,
+                    UserSettings = "{}"
+                }
+            };
+
+            _authServiceMock
+                .Setup(s => s.LoginAsync(request))
+                .ReturnsAsync(expectedResponse);
+
+            // Act
+            var result = await _controller.GoogleLogin(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+            Assert.Same(expectedResponse, okResult.Value);
+
+            _authServiceMock.Verify(s => s.LoginAsync(request), Times.Once);
+        }
+
+        [Fact]
+        public async Task GoogleLogin_PropagatesException_WhenServiceThrows()
+        {
+            // Arrange
+            var request = new GoogleLoginRequest
+            {
+                IdToken = "test-token"
+            };
+
+            _authServiceMock
+                .Setup(s => s.LoginAsync(request))
+                .ThrowsAsync(new InvalidOperationException("Auth failed"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.GoogleLogin(request));
+
+            _authServiceMock.Verify(s => s.LoginAsync(request), Times.Once);
+        }
+
+        [Fact]
+        public async Task GoogleLogin_WhenRequestIsNull_PropagatesServiceException()
+        {
+            // Arrange
+            GoogleLoginRequest? request = null;
+
+            _authServiceMock
+                .Setup(s => s.LoginAsync(null!))
+                .ThrowsAsync(new ArgumentNullException(nameof(request)));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _controller.GoogleLogin(request!));
+
+            _authServiceMock.Verify(s => s.LoginAsync(null!), Times.Once);
+        }
+    }
+}

--- a/CloudSyncTests/Unit/UserManagement/Controllers/InvitedUserControllerTests.cs
+++ b/CloudSyncTests/Unit/UserManagement/Controllers/InvitedUserControllerTests.cs
@@ -1,0 +1,187 @@
+using Microsoft.AspNetCore.Mvc;
+using CloudSync.Modules.UserManagement.Controllers;
+using CloudSync.Modules.UserManagement.Services.Interfaces;
+using Moq;
+using Shared.Requests.UserManagement;
+using Shared.Responses.UserManagement;
+
+namespace Tests.Unit.UserManagement.Controllers
+{
+    public class InvitedUserControllerTests
+    {
+        private readonly Mock<IInvitedUserService> _invitedUserServiceMock;
+        private readonly InvitedUserController _controller;
+
+        public InvitedUserControllerTests()
+        {
+            _invitedUserServiceMock = new Mock<IInvitedUserService>();
+            _controller = new InvitedUserController(_invitedUserServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task GetInvitedUsers_WhenUsersExist_ReturnsOkWithList()
+        {
+            // Arrange
+            var users = new List<InvitedUserResponse>
+            {
+                new InvitedUserResponse
+                {
+                    Id = 1,
+                    Email = "user1@example.com",
+                    InvitedByEmployeeId = 10,
+                    Status = default!
+                },
+                new InvitedUserResponse
+                {
+                    Id = 2,
+                    Email = "user2@example.com",
+                    InvitedByEmployeeId = 11,
+                    Status = default!
+                }
+            };
+
+            _invitedUserServiceMock.Setup(s => s.GetAllAsync())
+                                   .ReturnsAsync(users);
+
+            // Act
+            var result = await _controller.GetInvitedUsers();
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(users, ok.Value);
+
+            _invitedUserServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetInvitedUsers_WhenNoUsers_ReturnsOkWithEmptyList()
+        {
+            // Arrange
+            _invitedUserServiceMock.Setup(s => s.GetAllAsync())
+                                   .ReturnsAsync(new List<InvitedUserResponse>());
+
+            // Act
+            var result = await _controller.GetInvitedUsers();
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var list = Assert.IsAssignableFrom<IEnumerable<InvitedUserResponse>>(ok.Value);
+            Assert.Empty(list);
+
+            _invitedUserServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetInvitedUsers_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            _invitedUserServiceMock.Setup(s => s.GetAllAsync())
+                                   .ThrowsAsync(new InvalidOperationException("Service failure"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.GetInvitedUsers());
+
+            _invitedUserServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task InviteUser_WithValidRequest_ReturnsOkWithResponse()
+        {
+            // Arrange
+            var request = new InvitedUserRequest
+            {
+                Email = "new.user@example.com",
+                InvitedByEmployeeId = 99
+            };
+
+            var expected = new InvitedUserResponse
+            {
+                Id = 123,
+                Email = request.Email,
+                InvitedByEmployeeId = request.InvitedByEmployeeId,
+                Status = default!
+            };
+
+            _invitedUserServiceMock.Setup(s => s.InviteUserAsync(request))
+                                   .ReturnsAsync(expected);
+
+            // Act
+            var result = await _controller.InviteUser(request);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(expected, ok.Value);
+
+            _invitedUserServiceMock.Verify(s => s.InviteUserAsync(request), Times.Once);
+        }
+
+        [Fact]
+        public async Task InviteUser_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var request = new InvitedUserRequest
+            {
+                Email = "fail.user@example.com",
+                InvitedByEmployeeId = 42
+            };
+
+            _invitedUserServiceMock.Setup(s => s.InviteUserAsync(request))
+                                   .ThrowsAsync(new Exception("Invite failed"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(() => _controller.InviteUser(request));
+
+            _invitedUserServiceMock.Verify(s => s.InviteUserAsync(request), Times.Once);
+        }
+
+        [Fact]
+        public async Task InviteUser_WhenRequestIsNull_PropagatesServiceException()
+        {
+            // Arrange
+            InvitedUserRequest? request = null;
+
+            _invitedUserServiceMock.Setup(s => s.InviteUserAsync(null!))
+                                   .ThrowsAsync(new ArgumentNullException(nameof(request)));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _controller.InviteUser(request!));
+
+            _invitedUserServiceMock.Verify(s => s.InviteUserAsync(null!), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteInvite_WithValidId_ReturnsNoContent()
+        {
+            // Arrange
+            var id = 123;
+
+            _invitedUserServiceMock.Setup(s => s.DeleteInviteAsync(id))
+                                   .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.DeleteInvite(id);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+
+            _invitedUserServiceMock.Verify(s => s.DeleteInviteAsync(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteInvite_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var id = 456;
+
+            _invitedUserServiceMock.Setup(s => s.DeleteInviteAsync(id))
+                                   .ThrowsAsync(new KeyNotFoundException("Invite not found"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => _controller.DeleteInvite(id));
+
+            _invitedUserServiceMock.Verify(s => s.DeleteInviteAsync(id), Times.Once);
+        }
+    }
+}

--- a/CloudSyncTests/Unit/UserManagement/Controllers/UserControllerTests.cs
+++ b/CloudSyncTests/Unit/UserManagement/Controllers/UserControllerTests.cs
@@ -1,0 +1,224 @@
+using Microsoft.AspNetCore.Mvc;
+using CloudSync.Modules.UserManagement.Controllers;
+using CloudSync.Modules.UserManagement.Services.Interfaces;
+using Moq;
+using Shared.Responses.UserManagement;
+using Shared.UserManagement.Requests;
+
+namespace Tests.Unit.UserManagement.Controllers
+{
+    public class UserControllerTests
+    {
+        private readonly Mock<IUserService> _userServiceMock;
+        private readonly UserController _controller;
+
+        public UserControllerTests()
+        {
+            _userServiceMock = new Mock<IUserService>();
+            _controller = new UserController(_userServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task GetUsers_WhenUsersExist_ReturnsOkWithList()
+        {
+            // Arrange
+            var users = new List<UserResponse>
+            {
+                new UserResponse
+                {
+                    Id = 1,
+                    Email = "user1@example.com",
+                    CreateDateTime = DateTime.UtcNow.AddDays(-5),
+                    LastLoginDateTime = DateTime.UtcNow.AddDays(-1),
+                    UserSettings = "{}"
+                },
+                new UserResponse
+                {
+                    Id = 2,
+                    Email = "user2@example.com",
+                    CreateDateTime = DateTime.UtcNow.AddDays(-7),
+                    LastLoginDateTime = DateTime.UtcNow.AddDays(-2),
+                    UserSettings = null
+                }
+            };
+
+            _userServiceMock.Setup(s => s.GetAllAsync())
+                            .ReturnsAsync(users);
+
+            // Act
+            var result = await _controller.GetUsers();
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(users, ok.Value);
+
+            _userServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUsers_WhenNoUsers_ReturnsOkWithEmptyList()
+        {
+            // Arrange
+            _userServiceMock.Setup(s => s.GetAllAsync())
+                            .ReturnsAsync(new List<UserResponse>());
+
+            // Act
+            var result = await _controller.GetUsers();
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var list = Assert.IsAssignableFrom<IEnumerable<UserResponse>>(ok.Value);
+            Assert.Empty(list);
+
+            _userServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUsers_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            _userServiceMock.Setup(s => s.GetAllAsync())
+                            .ThrowsAsync(new InvalidOperationException("Service failure"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.GetUsers());
+
+            _userServiceMock.Verify(s => s.GetAllAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUser_WithValidId_ReturnsOkWithUser()
+        {
+            // Arrange
+            var id = 123;
+            var user = new UserResponse
+            {
+                Id = id,
+                Email = "user@example.com",
+                CreateDateTime = DateTime.UtcNow.AddDays(-10),
+                LastLoginDateTime = DateTime.UtcNow.AddDays(-1),
+                UserSettings = "{}"
+            };
+
+            _userServiceMock.Setup(s => s.GetByIdAsync(id))
+                            .ReturnsAsync(user);
+
+            // Act
+            var result = await _controller.GetUser(id);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(200, ok.StatusCode);
+            Assert.Same(user, ok.Value);
+
+            _userServiceMock.Verify(s => s.GetByIdAsync(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUser_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var id = 999;
+
+            _userServiceMock.Setup(s => s.GetByIdAsync(id))
+                            .ThrowsAsync(new KeyNotFoundException("User not found"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => _controller.GetUser(id));
+
+            _userServiceMock.Verify(s => s.GetByIdAsync(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task PutUser_WithValidRequest_ReturnsNoContent()
+        {
+            // Arrange
+            var id = 5;
+            var request = new UpdateUserRequest
+            {
+                Id = 456,
+                Email = "updated@example.com",
+                GoogleUserId = "updated-google-id"
+            };
+
+            _userServiceMock.Setup(s => s.UpdateAsync(id, request))
+                            .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.PutUser(id, request);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+            _userServiceMock.Verify(s => s.UpdateAsync(id, request), Times.Once);
+        }
+
+        [Fact]
+        public async Task PutUser_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var id = 42;
+            var request = new UpdateUserRequest
+            {
+                Id = 456,
+                Email = "updated@example.com",
+                GoogleUserId = "updated-google-id"
+            };
+            
+            _userServiceMock.Setup(s => s.UpdateAsync(id, request))
+                            .ThrowsAsync(new InvalidOperationException("Update failed"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _controller.PutUser(id, request));
+
+            _userServiceMock.Verify(s => s.UpdateAsync(id, request), Times.Once);
+        }
+
+        [Fact]
+        public async Task PutUser_WhenRequestIsNull_PropagatesServiceException()
+        {
+            // Arrange
+            var id = 1;
+
+            _userServiceMock.Setup(s => s.UpdateAsync(id, null!))
+                            .ThrowsAsync(new ArgumentNullException("request"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _controller.PutUser(id, null!));
+
+            _userServiceMock.Verify(s => s.UpdateAsync(id, null!), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteUser_WithValidId_ReturnsNoContent()
+        {
+            // Arrange
+            var id = 7;
+
+            _userServiceMock.Setup(s => s.DeleteAsync(id))
+                            .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.DeleteUser(id);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+            _userServiceMock.Verify(s => s.DeleteAsync(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteUser_WhenServiceThrows_PropagatesException()
+        {
+            // Arrange
+            var id = 404;
+
+            _userServiceMock.Setup(s => s.DeleteAsync(id))
+                            .ThrowsAsync(new KeyNotFoundException("User not found"));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => _controller.DeleteUser(id));
+
+            _userServiceMock.Verify(s => s.DeleteAsync(id), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for our backend API controllers, completing the testing for the `CloudSync` controller layer. I've created test suites for all controllers in both the `UserManagement` and `EmployeeManagement` modules. The tests verify that each API endpoint correctly handles requests, interacts with its service dependency as expected, and returns the appropriate HTTP result for success, empty, and exception scenarios. This work ensures our API endpoints are behaving correctly and moves us significantly closer to our overall test coverage goal.